### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -33,7 +33,7 @@ class syntax_plugin_function extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('<function=.*?>',$mode,'plugin_function');
     }
     
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
           case DOKU_LEXER_SPECIAL :
             return array($state, $match);          
@@ -42,7 +42,7 @@ class syntax_plugin_function extends DokuWiki_Syntax_Plugin {
         }
     }
  
-    function render($mode, &$renderer, $indata) {
+    function render($mode, Doku_Renderer $renderer, $indata) {
         global $conf;
         if($mode == 'xhtml'){
           list($state, $data) = $indata;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
